### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,6 @@ Aino, which stands for AI Innovation and is a near-homophone of I Know, An ontol
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=oinone/oinone-pamirs&type=Date)](https://star-history.com/#oinone/oinone-pamirs&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=oinone/oinone-pamirs&type=Date)](https://star-history.dera.page/#oinone/oinone-pamirs&Date)
 
 > Found Oinone useful? A Star ⭐ helps more developers discover AI-native low-code. Thank you!

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -109,6 +109,6 @@ Aino 寓意 AI Innovation，谐音`I Know`，是基于本体论（Ontology）的
 
 ## ⭐ Star 趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=oinone/oinone-pamirs&type=Date)](https://star-history.com/#oinone/oinone-pamirs&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=oinone/oinone-pamirs&type=Date)](https://star-history.dera.page/#oinone/oinone-pamirs&Date)
 
 > 觉得 Oinone 有用？点个 Star ⭐ 能帮更多开发者发现它，谢谢支持！


### PR DESCRIPTION
The star history chart on the README is currently broken and fails to load for visitors due to GitHub stargazer API restrictions. This PR switches the chart to a working mirror so the star history renders correctly again, in both the English and Chinese READMEs.